### PR TITLE
画像・動画アップロードページのfirestore繋ぎ込みを実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "firebase": "^9.12.1",
     "geolib": "^3.3.3",
     "mapbox-gl": "^2.10.0",
+    "nanoid": "^4.0.0",
     "next": "12.2.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "react-icons": "^4.6.0",
     "react-webcam": "^7.0.1",
     "swr": "^1.3.0",
-    "three": "^0.145.0"
+    "three": "^0.145.0",
+    "valtio": "^1.7.4"
   },
   "devDependencies": {
     "@types/aframe": "^1.2.0",

--- a/src/hooks/useMatching.ts
+++ b/src/hooks/useMatching.ts
@@ -2,6 +2,9 @@ import { useEffect, useState } from "react"
 import { useRouter } from "next/router"
 
 import { listenMatching, Matching, matchingStatus } from "@/repository/matching"
+import { useUser } from "@/auth/useAuth"
+import { AppUser } from "@/types/user"
+import { startMatching } from "@/repository/matchingCreate"
 
 /**
  * マッチング情報を取得する
@@ -42,4 +45,21 @@ export const useMatchingWithRedirect = (matchingId: string) => {
   }, [matching, matchingId, router])
 
   return matching
+}
+
+/**
+ * マッチングの参加者情報を購読する
+ */
+export const useMatchingUsers = (matchingId: string) => {
+  const user = useUser()
+  const [matchingUsers, setMatchingUsers] = useState<AppUser[]>([])
+
+  useEffect(() => {
+    const unsubscribe = startMatching(matchingId, (matchingUser) => {
+      setMatchingUsers((prev) => [...prev, matchingUser])
+    })
+    return unsubscribe
+  }, [matchingId, user?.id])
+
+  return matchingUsers
 }

--- a/src/lib/generateId.ts
+++ b/src/lib/generateId.ts
@@ -1,0 +1,3 @@
+import { nanoid } from "nanoid"
+
+export const generateId = () => nanoid()

--- a/src/lib/useGeolocation.ts
+++ b/src/lib/useGeolocation.ts
@@ -4,12 +4,14 @@ export const useGeolocation = () => {
   const [position, setPosition] = useState<GeolocationPosition | null>(null)
 
   useEffect(() => {
-    navigator.geolocation.getCurrentPosition(console.log)
     const watchID = navigator.geolocation.watchPosition(
       (position) => {
         setPosition(position)
       },
-      () => {},
+      (e) => {
+        console.log(e)
+        window.alert("位置情報の取得に失敗しました")
+      },
       {
         enableHighAccuracy: true,
       },

--- a/src/pages/cupsel/[matchingId]/collect.tsx
+++ b/src/pages/cupsel/[matchingId]/collect.tsx
@@ -84,7 +84,7 @@ const Collect: NextPage = () => {
         あなたの写真や動画
       </Text>
       <Center>
-        <SimpleGrid className="pt-4" cols={3} spacing={3} verticalSpacing={3}>
+        <SimpleGrid className="w-full pt-4" cols={3} spacing={3} verticalSpacing={3}>
           <FileButton key="addButton" onChange={addFiles} accept="image/png,image/jpeg" multiple>
             {(props) => (
               <Box
@@ -95,6 +95,7 @@ const Collect: NextPage = () => {
                   width: "100%",
                   backgroundColor: theme.colors.gray[8],
                   border: "none",
+                  aspectRatio: "1 / 1",
                   "&:hover": {
                     backgroundColor: theme.colors.gray[6],
                     cursor: "pointer",

--- a/src/pages/cupsel/[matchingId]/collect.tsx
+++ b/src/pages/cupsel/[matchingId]/collect.tsx
@@ -9,41 +9,73 @@ import {
   useMantineTheme,
 } from "@mantine/core"
 import { NextPage } from "next"
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { FiPlusCircle } from "react-icons/fi"
 import { useRouter } from "next/router"
 
 import WalkthroughLayout from "@/view/layout/walkthrough"
 import UserAvater from "@/view/UserAvater"
+import { useMatchingUsers, useMatchingWithRedirect } from "@/hooks/useMatching"
+import { listenItemCount, postItem } from "@/repository/items"
+import { useUser } from "@/auth/useAuth"
+
+const useItemCount = (matchingId: string) => {
+  const [postedItemCount, setPostedItemCount] = useState<Record<string, number>>({})
+
+  useEffect(() => {
+    const unsubscribe = listenItemCount(matchingId, (postedItem) => {
+      setPostedItemCount((prev) => {
+        const newItemCount = { ...prev }
+        for (const userId of Object.keys(postedItem)) {
+          newItemCount[userId] = (newItemCount[userId] ?? 0) + postedItem[userId]
+        }
+        return newItemCount
+      })
+    })
+    return unsubscribe
+  }, [matchingId])
+
+  return postedItemCount
+}
 
 const Collect: NextPage = () => {
   const router = useRouter()
-  const matchingId = router.query.matchingId as string
   const theme = useMantineTheme()
+  const user = useUser()
+
+  const matchingId = router.query.matchingId as string
+  const matching = useMatchingWithRedirect(matchingId)
+  const matchingUsers = useMatchingUsers(matchingId)
+  const postedItemCount = useItemCount(matchingId)
+
   const [files, setFiles] = useState<File[]>([])
+  const [previewImages, setPreviewImages] = useState<string[]>([])
 
-  // TODO:本当はいい感じにとってくる
-  const users = [
-    {
-      id: "test",
-      name: "user name",
-      iconUrl:
-        "https://lh3.googleusercontent.com/a/ALm5wu3m4M-U62i3Z8U7BlyEJX4h4bzX4rIrhz3aI5m3=s96-c",
-    },
-  ]
+  const handleAddFiles = async (addedFiles: File[]) => {
+    if (user == null) {
+      window.alert("ログインしてください")
+      return
+    }
 
-  const addFiles = (addedFiles: File[]) => {
     setFiles((prev) => [...prev, ...addedFiles])
+
+    const previewUrls = addedFiles.map((file) => URL.createObjectURL(file))
+    setPreviewImages((prev) => [...prev, ...previewUrls])
+
+    try {
+      await postItem({ user, matchingId }, addedFiles)
+    } catch (e) {
+      window.alert("エラーが発生しました")
+    }
   }
 
-  const previews = files.map((file, index) => {
-    const imageUrl = URL.createObjectURL(file)
+  const previews = previewImages.map((url, index) => {
     return (
       <Image
-        key={index}
-        alt={file.name}
-        src={imageUrl}
-        imageProps={{ onLoad: () => URL.revokeObjectURL(imageUrl) }}
+        key={url}
+        alt=""
+        src={url}
+        imageProps={{ onLoad: () => URL.revokeObjectURL(url) }}
         styles={{
           figure: {
             width: "100%",
@@ -75,8 +107,12 @@ const Collect: NextPage = () => {
     >
       <Box className="pt-10 pb-16">
         <Group spacing={10}>
-          {users.map((user) => (
-            <UserAvater key={user.id} user={user} label={12} />
+          {matchingUsers.map((matchingUser) => (
+            <UserAvater
+              key={matchingUser.id}
+              user={matchingUser}
+              label={postedItemCount[matchingUser.id] ?? 0}
+            />
           ))}
         </Group>
       </Box>
@@ -85,7 +121,12 @@ const Collect: NextPage = () => {
       </Text>
       <Center>
         <SimpleGrid className="w-full pt-4" cols={3} spacing={3} verticalSpacing={3}>
-          <FileButton key="addButton" onChange={addFiles} accept="image/png,image/jpeg" multiple>
+          <FileButton
+            key="addButton"
+            onChange={handleAddFiles}
+            accept="image/png,image/jpeg"
+            multiple
+          >
             {(props) => (
               <Box
                 component="button"
@@ -96,6 +137,7 @@ const Collect: NextPage = () => {
                   backgroundColor: theme.colors.gray[8],
                   border: "none",
                   aspectRatio: "1 / 1",
+                  transition: "backgroundColor 1s",
                   "&:hover": {
                     backgroundColor: theme.colors.gray[6],
                     cursor: "pointer",

--- a/src/pages/cupsel/[matchingId]/collect.tsx
+++ b/src/pages/cupsel/[matchingId]/collect.tsx
@@ -44,8 +44,19 @@ const Collect: NextPage = () => {
         alt={file.name}
         src={imageUrl}
         imageProps={{ onLoad: () => URL.revokeObjectURL(imageUrl) }}
-        height="30vw"
-        width="30vw"
+        styles={{
+          figure: {
+            width: "100%",
+            height: "100%",
+          },
+          imageWrapper: {
+            aspectRatio: "1 / 1",
+            width: "100%",
+            height: "100%",
+          },
+        }}
+        height="100%"
+        width="100%"
       />
     )
   })
@@ -62,10 +73,10 @@ const Collect: NextPage = () => {
         router.push(`/cupsel/create`)
       }}
     >
-      <Box className="pb-16 pt-10">
+      <Box className="pt-10 pb-16">
         <Group spacing={10}>
           {users.map((user) => (
-            <UserAvater key={user.id} user={user} label={8} />
+            <UserAvater key={user.id} user={user} label={12} />
           ))}
         </Group>
       </Box>
@@ -80,13 +91,16 @@ const Collect: NextPage = () => {
                 component="button"
                 {...props}
                 sx={(theme) => ({
-                  height: "30vw",
-                  width: "30vw",
+                  height: "100%",
+                  width: "100%",
                   backgroundColor: theme.colors.gray[8],
                   border: "none",
                   "&:hover": {
                     backgroundColor: theme.colors.gray[6],
                     cursor: "pointer",
+                  },
+                  "&:focus": {
+                    backgroundColor: theme.colors.gray[8],
                   },
                 })}
               >

--- a/src/pages/cupsel/[matchingId]/lobby.tsx
+++ b/src/pages/cupsel/[matchingId]/lobby.tsx
@@ -1,34 +1,16 @@
 import { NextPage } from "next"
-import React, { useEffect, useState } from "react"
+import React, { useEffect } from "react"
 import { useRouter } from "next/router"
 import { Button, Group, Stack, Text } from "@mantine/core"
 
-import { startMatching, stopMatching } from "@/repository/matchingCreate"
-import { AppUser } from "@/types/user"
+import { stopMatching } from "@/repository/matchingCreate"
 import { useUser } from "@/auth/useAuth"
 import { matchingStatus } from "@/repository/matching"
-import { useMatchingWithRedirect } from "@/hooks/useMatching"
+import { useMatchingUsers, useMatchingWithRedirect } from "@/hooks/useMatching"
 import WalkthroughLayout from "@/view/layout/walkthrough"
 import UserAvater from "@/view/UserAvater"
 import Smartphone from "@/view/icons/Smartphone"
 import Wave from "@/view/icons/Wave"
-
-/**
- * マッチングの参加者情報を購読する
- */
-const useMatchingUsers = (matchingId: string) => {
-  const user = useUser()
-  const [matchingUsers, setMatchingUsers] = useState<AppUser[]>([])
-
-  useEffect(() => {
-    const unsubscribe = startMatching(matchingId, (matchingUser) => {
-      setMatchingUsers((prev) => [...prev, matchingUser])
-    })
-    return unsubscribe
-  }, [matchingId, user?.id])
-
-  return matchingUsers
-}
 
 const Lobby: NextPage = () => {
   const router = useRouter()

--- a/src/pages/cupsel/create.tsx
+++ b/src/pages/cupsel/create.tsx
@@ -1,4 +1,4 @@
-import { Box, Drawer, Text, useMantineTheme } from "@mantine/core"
+import { Box, Drawer, Text } from "@mantine/core"
 import { useCallback, useState } from "react"
 import Picker, { Theme } from "emoji-picker-react"
 import { useRouter } from "next/router"
@@ -9,6 +9,12 @@ import WalkthroughLayout from "@/view/layout/walkthrough"
 import { createMatching } from "@/repository/matchingCreate"
 import { useUser } from "@/auth/useAuth"
 import { useGeolocation } from "@/lib/useGeolocation"
+import {
+  capsuleColors,
+  cupsuleCreateInputState,
+  gpsColors,
+  useCupsuleCreateInput,
+} from "@/state/cupsuleCreateInput"
 
 import type { NextPage } from "next"
 import type { EmojiClickData } from "emoji-picker-react"
@@ -17,36 +23,23 @@ const CapsuleAdd: NextPage = () => {
   const router = useRouter()
   const location = useGeolocation()
   const user = useUser()
-  const theme = useMantineTheme()
-  const [capsuleColor, setCapsuleColor] = useState(theme.colors["brand"][3])
-  const [gpsColor, setGpsColor] = useState("#000000")
-  const [chosenEmoji, setChosenEmoji] = useState<EmojiClickData | null>(null)
+
+  const cupsuleCreateInput = useCupsuleCreateInput()
+
   const [opened, setOpened] = useState(false)
 
-  const capsuleColors = [
-    theme.colors["brand"][3],
-    "#9581F2",
-    "#F1ABDD",
-    "#EB5040",
-    "#DE6437",
-    "#F8D551",
-    "#6BE58B",
-    "#73E4E3",
-    "#2351D5",
-    "#000000",
-    "#D3DAE1",
-    "#FFFFFF",
-  ]
-
-  const gpsColors = ["#000000", "#FFFFFF"]
-
-  const onEmojiClick = (emoji: EmojiClickData, event: MouseEvent) => {
-    setChosenEmoji(emoji)
+  const onEmojiClick = (emoji: EmojiClickData) => {
+    cupsuleCreateInputState.emoji = emoji.emoji
     setOpened(false)
   }
 
   const handleClickNext = useCallback(async () => {
-    if (user == null || location?.coords == null) {
+    if (user == null) {
+      window.alert("ログインしてください")
+      return
+    }
+    if (location?.coords == null) {
+      window.alert("位置情報の利用を許可してください")
       return
     }
     const matchingId = await createMatching({ user, location: location?.coords })
@@ -63,9 +56,9 @@ const CapsuleAdd: NextPage = () => {
         onClickPrevOrClose={() => router.push("/")}
       >
         <CapsulePreview
-          capsuleColor={capsuleColor}
-          gpsColor={gpsColor}
-          emoji={chosenEmoji ? chosenEmoji.emoji : "😄"}
+          capsuleColor={cupsuleCreateInput.color}
+          gpsColor={cupsuleCreateInput.gpsTextColor}
+          emoji={cupsuleCreateInput.emoji}
           lng={location?.coords.longitude ?? 0}
           lat={location?.coords.latitude ?? 0}
         />
@@ -73,7 +66,12 @@ const CapsuleAdd: NextPage = () => {
           <Text color="white" weight="bold" size="sm">
             カプセルの色
           </Text>
-          <ColorSelector colors={capsuleColors} onSelect={setCapsuleColor} />
+          <ColorSelector
+            colors={capsuleColors}
+            onSelect={(color) => {
+              cupsuleCreateInputState.color = color
+            }}
+          />
         </Box>
         <Box className="p-4">
           <Text color="white" weight="bold" size="sm">
@@ -109,7 +107,12 @@ const CapsuleAdd: NextPage = () => {
           <Text color="white" weight="bold" size="sm">
             GPSロゴの色
           </Text>
-          <ColorSelector colors={gpsColors} onSelect={setGpsColor} />
+          <ColorSelector
+            colors={gpsColors}
+            onSelect={(gpsColor) => {
+              cupsuleCreateInputState.gpsTextColor = gpsColor
+            }}
+          />
         </Box>
       </WalkthroughLayout>
       <Drawer

--- a/src/repository/items.ts
+++ b/src/repository/items.ts
@@ -1,0 +1,65 @@
+import { onSnapshot, collection, doc, writeBatch, serverTimestamp } from "firebase/firestore"
+import { getDownloadURL, ref, uploadBytes, UploadResult } from "firebase/storage"
+
+import { db, storage } from "@/lib/firebase/init"
+import { generateId } from "@/lib/generateId"
+import { AppUser } from "@/types/user"
+
+/**
+ * マッチングの中で投稿された画像の枚数
+ * @returns 購読を止める
+ */
+export const listenItemCount = (
+  matchingId: string,
+  onItemAdded: (itemUpdates: Record<string, number>) => void,
+) => {
+  const matchRef = collection(doc(collection(db, "matching"), matchingId), "items")
+  const unsubscribe = onSnapshot(matchRef, (snapshots) => {
+    snapshots.docChanges().forEach((docChange) => {
+      const itemUpdates: Record<string, number> = {}
+      if (docChange.type === "added") {
+        const data = docChange.doc.data()
+        const createdBy = data.createdBy
+        itemUpdates[createdBy] = (itemUpdates[createdBy] ?? 0) + 1
+      }
+      console.log(itemUpdates)
+      onItemAdded(itemUpdates)
+    })
+  })
+  return unsubscribe
+}
+
+export const postItem = async (
+  { user, matchingId }: { user: AppUser; matchingId: string },
+  files: File[],
+) => {
+  const fileObjects = files.map((file) => ({ id: generateId(), file }))
+  const results = await Promise.allSettled(
+    fileObjects.map(({ file, id }) =>
+      uploadBytes(ref(storage, `cupsules/${matchingId}/${id}`), file),
+    ),
+  )
+
+  const downloadUrls = await Promise.allSettled(
+    results
+      .filter(
+        (result): result is PromiseFulfilledResult<UploadResult> => result.status === "fulfilled",
+      )
+      .map((result) => getDownloadURL(result.value.ref)),
+  )
+
+  const matchRef = collection(doc(collection(db, "matching"), matchingId), "items")
+
+  const batch = writeBatch(db)
+  downloadUrls.forEach((downloadUrl, i) => {
+    if (downloadUrl.status === "fulfilled") {
+      batch.set(doc(matchRef, fileObjects[i].id), {
+        itemurl: downloadUrl.value,
+        createdBy: user.id,
+        createdAt: serverTimestamp(),
+      })
+    }
+  })
+  await batch.commit()
+  console.log("batch end")
+}

--- a/src/state/cupsuleCreateInput.ts
+++ b/src/state/cupsuleCreateInput.ts
@@ -1,0 +1,38 @@
+import { proxy, useSnapshot } from "valtio"
+
+export type CupsuleCreateInput = {
+  color: typeof capsuleColors[number] | string
+  emoji: string
+  gpsTextColor: typeof gpsColors[number] | string
+  title: string
+  unlockedAt: Date | null
+  memo: string
+}
+
+export const capsuleColors = [
+  "#D3F36B" as const,
+  "#9581F2" as const,
+  "#F1ABDD" as const,
+  "#EB5040" as const,
+  "#DE6437" as const,
+  "#F8D551" as const,
+  "#6BE58B" as const,
+  "#73E4E3" as const,
+  "#2351D5" as const,
+  "#000000" as const,
+  "#D3DAE1" as const,
+  "#FFFFFF" as const,
+]
+
+export const gpsColors = ["#000000" as const, "#FFFFFF" as const]
+
+export const cupsuleCreateInputState = proxy<CupsuleCreateInput>({
+  color: capsuleColors[0],
+  emoji: "🥩",
+  gpsTextColor: gpsColors[0],
+  title: "",
+  unlockedAt: null,
+  memo: "",
+})
+
+export const useCupsuleCreateInput = () => useSnapshot(cupsuleCreateInputState)

--- a/src/view/UserAvater.tsx
+++ b/src/view/UserAvater.tsx
@@ -23,6 +23,7 @@ const UserAvater: React.FC<UserAvaterProps> = ({ user, label }) => {
             border: "white 2px solid",
             backgroundColor: theme.colors.secondary[5],
             color: theme.colors.gray[9],
+            fontWeight: "bold",
           },
         })}
       >

--- a/yarn.lock
+++ b/yarn.lock
@@ -3802,6 +3802,11 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
+proxy-compare@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/proxy-compare/-/proxy-compare-2.3.0.tgz#ac9633ae52918ff9c9fcc54dfe6316c7a02d20ee"
+  integrity sha512-c3L2CcAi7f7pvlD0D7xsF+2CQIW8C3HaYx2Pfgq8eA4HAl3GAH6/dVYsyBbYF/0XJs2ziGLrzmz5fmzPm6A0pQ==
+
 proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
@@ -4661,6 +4666,14 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+valtio@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/valtio/-/valtio-1.7.4.tgz#07d9b1d4b4f49120474c4b861f0a1425ae3a2bb5"
+  integrity sha512-x8N7I7hfIlRHQyRe8cx3QJsEYdzMHb12HYUGIDjPruEwLrMpegvS8iZDk4PZ/i8HgeiOPF7Qr78Ke3HA1CGu9A==
+  dependencies:
+    proxy-compare "2.3.0"
+    use-sync-external-store "1.2.0"
 
 vary@~1.1.2:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3286,6 +3286,11 @@ nanoid@^3.3.4:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
 
+nanoid@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-4.0.0.tgz#6e144dee117609232c3f415c34b0e550e64999a5"
+  integrity sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"


### PR DESCRIPTION
close #36 

## やったこと
- 画像・動画アップロードページのfirestore繋ぎ込みを実装
  - 画像・動画のstorageへのアップロードを実装
  - firestoreへの保存
  - リアルタイム反映
- useMathcingUsers hookをリファクタ

<!--
### スクリーンショット
-->

<!--
## やっていないこと
-->

<!--
## 動作確認方法
-->

<!--
# 補足・参考リンク
-->
