### PR TITLE
カプセルの作成フローの改善

### DIFF
--- a/src/pages/PreviewItem.tsx
+++ b/src/pages/PreviewItem.tsx
@@ -1,0 +1,60 @@
+import React from "react"
+import { Image, Loader } from "@mantine/core"
+import { AiOutlineVideoCamera } from "react-icons/ai"
+
+export type PreviewItemProps = {
+  url: string
+  isLoading?: boolean
+  isVideo?: boolean
+}
+
+const PreviewItem: React.FC<PreviewItemProps> = ({ url, isLoading = false, isVideo = false }) => {
+  return (
+    <div className="relative">
+      {isVideo ? (
+        <video
+          src={url}
+          className="aspect-square h-full w-full object-cover"
+          muted
+          playsInline
+          autoPlay
+        />
+      ) : (
+        <Image
+          alt=""
+          src={url}
+          imageProps={{ onLoad: () => URL.revokeObjectURL(url) }}
+          styles={{
+            figure: {
+              width: "100%",
+              height: "100%",
+            },
+            imageWrapper: {
+              aspectRatio: "1 / 1",
+              width: "100%",
+              height: "100%",
+            },
+          }}
+          height="100%"
+          width="100%"
+        />
+      )}
+      {isVideo && (
+        <div className="absolute top-2 right-2 text-white">
+          <AiOutlineVideoCamera />
+        </div>
+      )}
+      {isLoading && (
+        <>
+          <div className="absolute inset-0 animate-pulse bg-gray-900/50" />
+          <Loader
+            color="white"
+            className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 opacity-50"
+          />
+        </>
+      )}
+    </div>
+  )
+}
+
+export default PreviewItem

--- a/src/pages/capsule/[matchingId]/collect.tsx
+++ b/src/pages/capsule/[matchingId]/collect.tsx
@@ -1,19 +1,8 @@
-import {
-  Box,
-  Center,
-  FileButton,
-  Group,
-  Image,
-  Loader,
-  SimpleGrid,
-  Text,
-  useMantineTheme,
-} from "@mantine/core"
+import { Box, Center, FileButton, Group, SimpleGrid, Text, useMantineTheme } from "@mantine/core"
 import { NextPage } from "next"
 import React, { useEffect, useState } from "react"
 import { FiPlusCircle } from "react-icons/fi"
 import { useRouter } from "next/router"
-import { AiOutlineVideoCamera } from "react-icons/ai"
 
 import WalkthroughLayout from "@/view/layout/walkthrough"
 import UserAvater from "@/view/UserAvater"
@@ -24,6 +13,7 @@ import MetaHeader from "@/view/common/MetaHeader"
 import { useAuthRouter } from "@/auth/useAuthRouter"
 import { generateId } from "@/lib/generateId"
 import { Item } from "@/types/item"
+import PreviewItem from "@/pages/PreviewItem"
 
 const useItemCount = ({ userId, matchingId }: { userId: string; matchingId: string }) => {
   const [postedItems, setPostedItems] = useState<Item[]>([])
@@ -86,42 +76,8 @@ const Collect: NextPage = () => {
   const previews = previewImages.map(({ id, url }) => {
     const postedItem = postedItems.find((item) => item.id === id)
     const postCompleted = postedItem != null
-    return (
-      <div key={id} className="relative">
-        <Image
-          alt=""
-          src={url}
-          imageProps={{ onLoad: () => URL.revokeObjectURL(url) }}
-          styles={{
-            figure: {
-              width: "100%",
-              height: "100%",
-            },
-            imageWrapper: {
-              aspectRatio: "1 / 1",
-              width: "100%",
-              height: "100%",
-            },
-          }}
-          height="100%"
-          width="100%"
-        />
-        {postedItem?.mimeType?.startsWith("video") && (
-          <div className="absolute top-2 right-2 text-white">
-            <AiOutlineVideoCamera />
-          </div>
-        )}
-        {!postCompleted && (
-          <>
-            <div className="absolute inset-0 animate-pulse bg-gray-900/50" />
-            <Loader
-              color="white"
-              className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 opacity-50"
-            />
-          </>
-        )}
-      </div>
-    )
+    const isVideo = postedItem?.mimeType?.startsWith("video") ?? false
+    return <PreviewItem key={id} url={url} isLoading={!postCompleted} isVideo={isVideo} />
   })
 
   const previousPostedPreviews = postedItems
@@ -133,43 +89,7 @@ const Collect: NextPage = () => {
       }
       const isVideo = item?.mimeType?.startsWith("video")
 
-      return (
-        <div key={item.id} className="relative">
-          {isVideo ? (
-            <video
-              src={item.itemUrl}
-              className="aspect-square h-full w-full object-cover"
-              muted
-              playsInline
-              autoPlay
-            />
-          ) : (
-            <Image
-              alt=""
-              src={item.itemUrl}
-              imageProps={{ onLoad: () => URL.revokeObjectURL(item.itemUrl) }}
-              styles={{
-                figure: {
-                  width: "100%",
-                  height: "100%",
-                },
-                imageWrapper: {
-                  aspectRatio: "1 / 1",
-                  width: "100%",
-                  height: "100%",
-                },
-              }}
-              height="100%"
-              width="100%"
-            />
-          )}
-          {isVideo && (
-            <div className="absolute top-2 right-2 text-white">
-              <AiOutlineVideoCamera />
-            </div>
-          )}
-        </div>
-      )
+      return <PreviewItem key={item.id} url={item.itemUrl} isVideo={isVideo} />
     })
 
   return (

--- a/src/pages/capsule/[matchingId]/lobby.tsx
+++ b/src/pages/capsule/[matchingId]/lobby.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from "react"
 import { useRouter } from "next/router"
 import { Button, Group, Stack, Text } from "@mantine/core"
 
-import { stopMatching } from "@/repository/matchingCreate"
+import { goCollectPhase } from "@/repository/matchingCreate"
 import { useUser } from "@/auth/useAuth"
 import { matchingStatus } from "@/repository/matching"
 import { useMatchingUsers, useMatchingWithRedirect } from "@/hooks/useMatching"
@@ -16,6 +16,7 @@ import { useAuthRouter } from "@/auth/useAuthRouter"
 
 const Lobby: NextPage = () => {
   useAuthRouter(true)
+
   const router = useRouter()
   const user = useUser()
   const matchingId = router.query.matchingId as string
@@ -26,7 +27,7 @@ const Lobby: NextPage = () => {
   const isOwner = matching != null && user != null && matching.ownerId === user.id
 
   const handleConfirmMembers = async () => {
-    await stopMatching(matchingId)
+    await goCollectPhase(matchingId)
   }
 
   useEffect(() => {

--- a/src/pages/capsule/[matchingId]/register.tsx
+++ b/src/pages/capsule/[matchingId]/register.tsx
@@ -49,55 +49,59 @@ const Register: NextPage = () => {
   const [isSaveSuccessed, setIsSaveSuccessed] = useState(false)
 
   const save = async () => {
-    setIsSaving(true)
     if (user == null) {
       window.alert("ログインしてください")
-      onFailCreateCapsule()
       return
     }
 
-    if (isOwner) {
-      if (capsuleCreateInput.title == "" || capsuleCreateInput.openDate == null) {
-        window.alert("タイトル、開封日を設定してください")
-        onFailCreateCapsule()
-        return
+    if (isOwner && (capsuleCreateInput.title == "" || capsuleCreateInput.openDate == null)) {
+      window.alert("タイトル、開封日を設定してください")
+      return
+    }
+
+    try {
+      setIsSaving(true)
+
+      if (isOwner) {
+        await postCapsule({ matchingId, user }, capsuleCreateInput, geolocation)
+      } else {
+        await joinCapsule({ matchingId, user }, capsuleCreateInput.memo)
       }
 
-      await postCapsule({ matchingId, user }, capsuleCreateInput, geolocation)
-    } else {
-      await joinCapsule({ matchingId, user }, capsuleCreateInput.memo)
-    }
+      const feature: CreateFeature = {
+        type: "Feature",
+        geometry: {
+          type: "Point",
+          coordinates: [geolocation.longitude, geolocation.latitude],
+        },
+        properties: {
+          id: matchingId,
+          capsuleColor: capsuleCreateInput.color,
+          gpsColor: capsuleCreateInput.gpsTextColor,
+          emoji: capsuleCreateInput.emoji,
+          addDate: new Date().toISOString(),
+          openDate: (capsuleCreateInput.openDate ?? add(new Date(), { years: 1 })).toISOString(),
+        },
+      }
 
-    const feature: CreateFeature = {
-      type: "Feature",
-      geometry: {
-        type: "Point",
-        coordinates: [geolocation.longitude, geolocation.latitude],
-      },
-      properties: {
-        id: matchingId,
-        capsuleColor: capsuleCreateInput.color,
-        gpsColor: capsuleCreateInput.gpsTextColor,
-        emoji: capsuleCreateInput.emoji,
-        addDate: new Date().toISOString(),
-        openDate: (capsuleCreateInput.openDate ?? add(new Date(), { years: 1 })).toISOString(),
-      },
+      // レイヤーを作る
+      // 既にある(=エラー)なら正しいレイヤーを探す
+      // 物件を追加
+      try {
+        const layerId = await postLayer(user.id)
+        await postFeature(feature, layerId)
+      } catch (e: any) {
+        if (e.message === "ALREADY_EXISTS") {
+          const layers = await searchLayerID(user.id)
+          await Promise.all(layers.map((layer) => postFeature(feature, layer.id)))
+        } else {
+          throw e
+        }
+      }
+      onSucsessCreateCapsule()
+    } finally {
+      setIsSaving(false)
     }
-
-    // レイヤーを作る
-    // 既にある(=エラー)なら正しいレイヤーを探す
-    // 物件を追加
-    postLayer(
-      user.id,
-      (res) => {
-        postFeature(feature, res.data.id, onSucsessCreateCapsule, onFailCreateCapsule)
-      },
-      () => {
-        searchLayerID(user.id, (id) => {
-          postFeature(feature, id, onSucsessCreateCapsule, onFailCreateCapsule)
-        })
-      },
-    )
   }
 
   const moveToMap = () => {
@@ -106,20 +110,12 @@ const Register: NextPage = () => {
 
   const onSucsessCreateCapsule = () => {
     setIsSaveSuccessed(true)
-    setIsSaving(false)
     clearCapsuleCreateInput()
   }
-  const onFailCreateCapsule = () => {
-    setIsSaving(false)
-  }
 
-  const postLayer = (
-    name: string,
-    callback: (res: any) => void,
-    errorCallback: (err: any) => void,
-  ) => {
-    axios
-      .post(
+  const postLayer = async (name: string) => {
+    try {
+      const res = await axios.post<{ id: number }>(
         `https://prod-mqplatform-api.azure-api.net/maps-api/layers/v1/18?subscription_key=${process.env.NEXT_PUBLIC_MAP_SUBSCRIPTION_KEY}`,
         {
           name: name,
@@ -132,46 +128,27 @@ const Register: NextPage = () => {
           },
         },
       )
-      .then((res) => {
-        callback(res)
-      })
-      .catch((err) => {
-        errorCallback(err)
-      })
+      return res.data.id
+    } catch (e) {
+      console.error(e)
+      throw new Error("ALREADY_EXISTS")
+    }
   }
 
-  const searchLayerID = (name: string, callback: (res: any) => void) => {
-    axios
-      .get(
-        `https://prod-mqplatform-api.azure-api.net/maps-api/layers/v1/18?subscription_key=${process.env.NEXT_PUBLIC_MAP_SUBSCRIPTION_KEY}`,
-      )
-      .then((res) => {
-        // @ts-ignore
-        res.data.forEach((layer) => {
-          if (layer.name == name) {
-            callback(layer.id)
-          }
-        })
-      })
+  const searchLayerID = async (name: string) => {
+    const res = await axios.get<{ id: number }[]>(
+      `https://prod-mqplatform-api.azure-api.net/maps-api/layers/v1/18?subscription_key=${process.env.NEXT_PUBLIC_MAP_SUBSCRIPTION_KEY}`,
+    )
+
+    return res.data.filter((layer: any) => layer.name == name)
   }
 
-  const postFeature = (
-    feature: CreateFeature,
-    id: number,
-    callback: (res: any) => void,
-    errorCallback: (error: any) => void,
-  ) => {
-    axios
-      .post(
-        `https://prod-mqplatform-api.azure-api.net/maps-api/features/v1/18/${id}?subscription_key=${process.env.NEXT_PUBLIC_MAP_SUBSCRIPTION_KEY}`,
-        feature,
-      )
-      .then((res) => {
-        callback(res)
-      })
-      .catch((err) => {
-        errorCallback(err)
-      })
+  const postFeature = async (feature: CreateFeature, id: number) => {
+    const res = await axios.post(
+      `https://prod-mqplatform-api.azure-api.net/maps-api/features/v1/18/${id}?subscription_key=${process.env.NEXT_PUBLIC_MAP_SUBSCRIPTION_KEY}`,
+      feature,
+    )
+    return res.data
   }
 
   return (

--- a/src/pages/capsule/[matchingId]/register.tsx
+++ b/src/pages/capsule/[matchingId]/register.tsx
@@ -30,6 +30,7 @@ import { useMatchingWithRedirect } from "@/hooks/useMatching"
 import { joinCapsule, postCapsule } from "@/repository/capsule"
 import MetaHeader from "@/view/common/MetaHeader"
 import { useAuthRouter } from "@/auth/useAuthRouter"
+import { goCollectPhase } from "@/repository/matchingCreate"
 
 const Register: NextPage = () => {
   useAuthRouter(true)
@@ -183,17 +184,17 @@ const Register: NextPage = () => {
         totalStep={4}
         currentStep={3}
         onClickNext={save}
-        onClickPrevOrClose={isOwner ? () => router.push(`/capsule/${matchingId}/collect`) : null}
+        onClickPrevOrClose={isOwner ? () => goCollectPhase(matchingId) : null}
         nextButtonType="bury"
       >
         <Box>
           <LoadingOverlay visible={isSaving} loaderProps={{ size: "xl" }} overlayOpacity={0.6} />
           <CapsulePreview
-            capsuleColor={capsuleCreateInput.color}
-            gpsColor={capsuleCreateInput.gpsTextColor}
-            emoji={capsuleCreateInput.emoji}
-            lng={geolocation.longitude ?? 0}
-            lat={geolocation.latitude ?? 0}
+            capsuleColor={matching?.color ?? capsuleCreateInput.color}
+            gpsColor={matching?.gpsTextColor ?? capsuleCreateInput.gpsTextColor}
+            emoji={matching?.emoji ?? capsuleCreateInput.emoji}
+            lng={matching?.longitude ?? geolocation?.latitude ?? 0}
+            lat={matching?.latitude ?? geolocation?.longitude ?? 0}
           />
           <Text className="pb-4" color="white" weight="bold" size="sm">
             カプセルの情報

--- a/src/pages/capsule/create.tsx
+++ b/src/pages/capsule/create.tsx
@@ -49,9 +49,22 @@ const CapsuleAdd: NextPage = () => {
       window.alert("位置情報の利用を許可してください")
       return
     }
-    const matchingId = await createMatching({ user, location })
+
+    const matchingId = await createMatching(user, {
+      location,
+      emoji: capsuleCreateInput.emoji,
+      color: capsuleCreateInput.color,
+      gpsTextColor: capsuleCreateInput.gpsTextColor,
+    })
     await router.push(`/capsule/${matchingId}/lobby`)
-  }, [location, router, user])
+  }, [
+    capsuleCreateInput.color,
+    capsuleCreateInput.emoji,
+    capsuleCreateInput.gpsTextColor,
+    location,
+    router,
+    user,
+  ])
 
   const { data: Theme } = useSWR("emoji-picker-react.Theme", () =>
     import("emoji-picker-react").then(({ Theme }) => Theme),

--- a/src/repository/items.ts
+++ b/src/repository/items.ts
@@ -6,6 +6,8 @@ import {
   serverTimestamp,
   updateDoc,
   getDocs,
+  query,
+  orderBy,
 } from "firebase/firestore"
 import { getDownloadURL, ref, uploadBytes, UploadResult } from "firebase/storage"
 
@@ -21,7 +23,10 @@ import { matchingStatus } from "./matching"
  * @returns 購読を止める
  */
 export const listenItems = (matchingId: string, onItemAdded: (itemUpdates: Item[]) => void) => {
-  const matchRef = collection(doc(collection(db, "matching"), matchingId), "items")
+  const matchRef = query(
+    collection(doc(collection(db, "matching"), matchingId), "items"),
+    orderBy("createdAt", "desc"),
+  )
   const unsubscribe = onSnapshot(matchRef, (snapshots) => {
     const addedItems = snapshots
       .docChanges()

--- a/src/repository/matching.ts
+++ b/src/repository/matching.ts
@@ -6,6 +6,11 @@ export type Matching = {
   id: string
   status: MatchingStatus
   ownerId: string
+  emoji: string
+  color: string
+  gpsTextColor: string
+  longitude: number
+  latitude: number
 }
 
 export const matchingStatus = {
@@ -31,6 +36,11 @@ export const listenMatching = (
       id,
       status: data.status,
       ownerId: data.id,
+      emoji: data.emoji,
+      color: data.color,
+      gpsTextColor: data.gpsTextColor,
+      longitude: data.longitude,
+      latitude: data.latitude,
     })
   })
 }

--- a/src/repository/matchingCreate.ts
+++ b/src/repository/matchingCreate.ts
@@ -22,7 +22,15 @@ import { matchingStatus } from "./matching"
  * マッチングを作成する
  * @returns マッチングID
  */
-export const createMatching = async ({ user, location }: { user: AppUser; location: LatLng }) => {
+export const createMatching = async (
+  user: AppUser,
+  {
+    location,
+    emoji,
+    color,
+    gpsTextColor,
+  }: { location: LatLng; emoji: string; color: string; gpsTextColor: string },
+) => {
   const matchingRef = await addDoc(collection(db, "matching"), {
     id: user.id,
     name: user.name,
@@ -31,6 +39,9 @@ export const createMatching = async ({ user, location }: { user: AppUser; locati
     longitude: location.longitude,
     createdAt: serverTimestamp(),
     status: matchingStatus.MEMBER_JOIN,
+    emoji,
+    color,
+    gpsTextColor,
   })
 
   await setDoc(doc(collection(doc(collection(db, "matching"), matchingRef.id), "users"), user.id), {
@@ -134,7 +145,7 @@ export const listenOngoingMatching = (
   return unsubscribe
 }
 
-export const stopMatching = async (matchingId: string) => {
+export const goCollectPhase = async (matchingId: string) => {
   await updateDoc(doc(collection(db, "matching"), matchingId), {
     status: matchingStatus.ITEM_COLLECT,
   })

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -1,0 +1,7 @@
+export type Item = {
+  id: string
+  createdBy: string
+  createdAt: string
+  itemUrl: string
+  mimeType: string
+}

--- a/src/view/Capsule.tsx
+++ b/src/view/Capsule.tsx
@@ -86,7 +86,11 @@ const Capsule: React.FC<CapsuleProps> = ({
           whiteSpace: "pre-wrap",
         }}
       >
-        {convertLngLat(lng, "lng") + "\n" + convertLngLat(lat, "lat")}
+        {convertLngLat(lng, "lng").split("'")[0] +
+          "'N" +
+          "\n" +
+          convertLngLat(lat, "lat").split("'")[0] +
+          "'E"}
       </Text>
     </Center>
   )

--- a/src/view/MatchingDialog.tsx
+++ b/src/view/MatchingDialog.tsx
@@ -87,7 +87,7 @@ const MatchingDialog: React.FC<MatchingDialogProps> = ({ children }) => {
             </Text>
           </Center>
         </div>
-        <Button color="brand.3" onClick={handleJoin} fullWidth size="md">
+        <Button color="brand.3" onClick={handleJoin} fullWidth size="md" data-autofocus>
           <Text color="black">参加する</Text>
         </Button>
       </Drawer>

--- a/src/view/UserAvater.tsx
+++ b/src/view/UserAvater.tsx
@@ -1,11 +1,11 @@
-import { Indicator, Stack, Avatar, Text } from "@mantine/core"
+import { Avatar, Indicator, Stack, Text } from "@mantine/core"
 import React from "react"
 
 import { AppUser } from "@/types/user"
 
 export type UserAvaterProps = {
   user: AppUser
-  label?: number
+  label?: React.ReactNode
 }
 
 const UserAvater: React.FC<UserAvaterProps> = ({ user, label }) => {

--- a/src/view/layout/walkthrough.tsx
+++ b/src/view/layout/walkthrough.tsx
@@ -22,7 +22,7 @@ const WalkthroughLayout: React.FC<WalkthroughLayoutProps> = ({
   nextButtonType = "default",
 }) => {
   return (
-    <Box sx={{ minHeight: "100vh", height: "100%", backgroundColor: "#212121" }} p={20}>
+    <Box className="min-h-screen" sx={{ height: "100%", backgroundColor: "#212121" }} p={20}>
       <Group className="w-full" position="apart">
         {onClickPrevOrClose != null ? (
           <ActionIcon aria-label="Close modal" size="lg" color="dark" onClick={onClickPrevOrClose}>

--- a/src/view/map/LockedCapsule.tsx
+++ b/src/view/map/LockedCapsule.tsx
@@ -17,56 +17,58 @@ const LockedCapsule: React.FC<LockedCapsuleProps> = ({ feature, className }) => 
   }
 
   return (
-    <RingProgress
-      size={120}
-      thickness={12}
-      className={className}
-      sections={[
-        {
-          value: 100 - (betweenDays(today, openDate) / betweenDays(addDate, openDate)) * 100,
-          color: "gray.8",
-        },
-        {
-          value: (betweenDays(today, openDate) / betweenDays(addDate, openDate)) * 100,
-          color: feature.properties.capsuleColor,
-        },
-      ]}
-      label={
-        <Stack
-          sx={(theme) => ({
-            backgroundColor: theme.colors.gray[9],
-            width: 120 - 12 * 4,
-            height: 120 - 12 * 4,
-            borderRadius: "50%",
-            justifyContent: "center",
-            gap: 0,
-          })}
-        >
-          <Text
-            sx={{
-              fontSize: 10,
-              fontWeight: 300,
-              fontFamily: "Hiragino Sans",
-              color: "white",
-              textAlign: "center",
-            }}
+    <div className="pb-[150px]">
+      <RingProgress
+        size={120}
+        thickness={12}
+        className={className}
+        sections={[
+          {
+            value: 100 - (betweenDays(today, openDate) / betweenDays(addDate, openDate)) * 100,
+            color: "gray.8",
+          },
+          {
+            value: (betweenDays(today, openDate) / betweenDays(addDate, openDate)) * 100,
+            color: feature.properties.capsuleColor,
+          },
+        ]}
+        label={
+          <Stack
+            sx={(theme) => ({
+              backgroundColor: theme.colors.gray[9],
+              width: 120 - 12 * 4,
+              height: 120 - 12 * 4,
+              borderRadius: "50%",
+              justifyContent: "center",
+              gap: 0,
+            })}
           >
-            残り
-          </Text>
-          <Text
-            sx={{
-              fontSize: 18,
-              fontWeight: 600,
-              fontFamily: "Hiragino Sans",
-              color: "white",
-              textAlign: "center",
-            }}
-          >
-            {betweenDays(today, openDate)}日
-          </Text>
-        </Stack>
-      }
-    />
+            <Text
+              sx={{
+                fontSize: 10,
+                fontWeight: 300,
+                fontFamily: "Hiragino Sans",
+                color: "white",
+                textAlign: "center",
+              }}
+            >
+              残り
+            </Text>
+            <Text
+              sx={{
+                fontSize: 18,
+                fontWeight: 600,
+                fontFamily: "Hiragino Sans",
+                color: "white",
+                textAlign: "center",
+              }}
+            >
+              {betweenDays(today, openDate)}日
+            </Text>
+          </Stack>
+        }
+      />
+    </div>
   )
 }
 

--- a/src/view/map/Map.tsx
+++ b/src/view/map/Map.tsx
@@ -86,6 +86,7 @@ const MapPage: React.FC<MapPageProps> = ({ selectedCapsuleCenter }) => {
       zoom: 16,
       bearing: -12,
       pitch: 60,
+      // maxZoom: 16.99,
     })
     mapRef.current = map
 

--- a/src/view/map/Map.tsx
+++ b/src/view/map/Map.tsx
@@ -175,7 +175,11 @@ const MapPage: React.FC<MapPageProps> = ({ selectedCapsuleCenter }) => {
                 `https://prod-mqplatform-api.azure-api.net/maps-api/features/v1/18/${layer.id}?subscription_key=${process.env.NEXT_PUBLIC_MAP_SUBSCRIPTION_KEY}`,
               )
               .then((res) => {
-                const sortedFeatures = res.data.features.sort(featureSortFunc).slice(1, 3)
+                const sortedFeatures = res.data.features.sort(featureSortFunc)
+                if (sortedFeatures.length === 0) {
+                  return
+                }
+
                 sortedFeatures.forEach((feature: Feature) => {
                   const div = document.createElement("div")
                   const root = createRoot(div)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,6 +17,10 @@ module.exports = {
       },
       height: {
         "map-screen": ["calc(100vh - 72px)", "calc(100dvh - 72px)"],
+        screen: ["100vh", "100dvh"],
+      },
+      minHeight: {
+        screen: ["100vh", "100dvh"],
       },
       boxShadow: {
         main: "0px 1px 6px rgba(132, 132, 132, 0.26)",


### PR DESCRIPTION
close #77 
## やったこと
- 写真アップロードページ
  - リロード後も投稿した写真が表示されるように変更
  - アップロード中の写真にローディング表示を追加
  - 動画のアップロードに対応（`image/png,image/jpeg,image/gif,video/webm,video/mpeg,video/mp4`）
  - 動画のプレビュー項目に動画アイコンを追加
- カプセル情報入力ページ
  - オーナー以外の参加者の端末でカプセルのデザインが反映されないバグを修正
  - 非同期処理をリファクタ
- 埋める処理
  - オーナー以外の参加者が、オーナーより先に埋めるボタンを押した際にエラーが出る問題を修正
  - 埋める処理をトランザクション化
- カプセルのデザイン
  - 緯度経度の文字列の表示文字数を削減
- 作成フローの全ページで、iOS Safariで不要なスクロールが発生していた問題を修正

<!--
### スクリーンショット
-->


## やっていないこと
- PC Chromeで動画をアップロードした際に、プレビュー動画が表示されない（iOS Safariではちゃんと表示されるので一旦スルー）

<!--
## 動作確認方法
-->

<!--
# 補足・参考リンク
-->
