### PR TITLE
地図のキャッシュ機能を削除

### DIFF
--- a/src/view/map/Map.tsx
+++ b/src/view/map/Map.tsx
@@ -211,7 +211,9 @@ const MapPage: React.FC<MapPageProps> = ({ selectedCapsuleCenter }) => {
                   camera.current,
                   scene.current,
                 )
-                map.removeLayer("features")
+                if (map.getLayer("features") != null) {
+                  map.removeLayer("features")
+                }
                 map.addLayer(customLayer)
               })
           }

--- a/src/view/map/Map.tsx
+++ b/src/view/map/Map.tsx
@@ -270,19 +270,20 @@ const MapPage: React.FC<MapPageProps> = ({ selectedCapsuleCenter }) => {
   }
 
   useEffect(() => {
-    if (mapElement == null) {
-      mapSetUp()
-    } else {
-      const container = mapContainerRef.current
-      for (let i = 0; i < mapElement.length; i++) {
-        container?.appendChild?.(mapElement.item(i))
-      }
-      mapRef.current = mapObj
-      // container?.appendChild?.(mapElement)
-      if (mapObj != null && user != null) {
-        setMarker(mapObj, user.id)
-      }
-    }
+    // NOTE: 不具合を観測したのでキャッシュを一旦削除
+    // if (mapElement == null) {
+    mapSetUp()
+    // } else {
+    //   const container = mapContainerRef.current
+    //   for (let i = 0; i < mapElement.length; i++) {
+    //     container?.appendChild?.(mapElement.item(i))
+    //   }
+    //   mapRef.current = mapObj
+    //   // container?.appendChild?.(mapElement)
+    //   if (mapObj != null && user != null) {
+    //     setMarker(mapObj, user.id)
+    //   }
+    // }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 


### PR DESCRIPTION
~~close #xxx~~

## やったこと
- 地図が表示されないバグがあったため、 #72 で導入した地図のキャッシュ機能を無効化

<!--
### スクリーンショット
-->

<!--
## やっていないこと
-->

<!--
## 動作確認方法
-->

<!--
# 補足・参考リンク
-->
