### PR TITLE
ARで開封可能な範囲を拡大

### DIFF
--- a/src/pages/capsule/open/[capsuleId]/index.tsx
+++ b/src/pages/capsule/open/[capsuleId]/index.tsx
@@ -18,7 +18,7 @@ import { convertLngLat } from "@/lib/convertLngLat"
 import { useCapsules } from "@/hooks/useCapsules"
 import DiscoverDrawer from "@/view/DiscoverDrawer"
 
-const CLOSE_DISTANCE_THRESHOLD = 50
+const CLOSE_DISTANCE_THRESHOLD = 500
 
 type CapsulePosition = Capsule & {
   x: number


### PR DESCRIPTION
close #xxx

## やったこと
- デモ用に、500m以内のカプセルを開封可能にした

<!--
### スクリーンショット
-->

<!--
## やっていないこと
-->

<!--
## 動作確認方法
-->

<!--
# 補足・参考リンク
-->
